### PR TITLE
Asar assembler

### DIFF
--- a/asm/banks/c0.asm
+++ b/asm/banks/c0.asm
@@ -202,16 +202,16 @@ org $C0BE03
 
 org $C0D613
 Level18:
-  LDA $1D4D        ; config settings
-  AND #$08         ; "Experience Enabled"
-  BNE .lvlup       ; branch if ^ (else, A=0)
+  LDA $1D4D          ; config settings
+  AND #$08           ; "Experience Enabled"
+  BNE .lvlup         ; branch if ^ (else, A=0)
 .finish
-  JMP $9F35        ; A will be minimum new level
+  JMP $9F35          ; A will be minimum new level
 .lvlup
-  LDA $EB          ; event param
-  TAX              ; X = character #
-  LDA RejoinLvl,X  ; A = rejoin level
-  BRA .finish      ; set new level
+  LDA $EB            ; event param
+  TAX                ; X = character #
+  LDA.L RejoinLvl,X  ; A = rejoin level
+  BRA .finish        ; set new level
 
 RejoinLvl:
   db $15 ; Terra

--- a/asm/banks/c0.asm
+++ b/asm/banks/c0.asm
@@ -210,7 +210,7 @@ Level18:
 .lvlup
   LDA $EB            ; event param
   TAX                ; X = character #
-  LDA.L RejoinLvl,X  ; A = rejoin level
+  LDA.l RejoinLvl,X  ; A = rejoin level
   BRA .finish        ; set new level
 
 RejoinLvl:

--- a/asm/banks/c1.asm
+++ b/asm/banks/c1.asm
@@ -56,8 +56,8 @@ UpdateAura:
 SetColor:
   AND #$E0           ; clear "wait" bit
   JSR $1A0F          ; convert bitmask to bit index in X
-  LDA .color_table,X ; get outline colour
-.color_table
+  LDA.L .clr_table,X ; get outline colour
+.clr_table
   BRA AuraControl  ; implement
   db $04 ; Slow [unused]
   db $03 ; Haste [unused]
@@ -729,16 +729,16 @@ Cascade:
 
 PrepMove:
   LDA #$08
-  STA $14        ; set x_pos for miss tiles
+  STA $14         ; set x_pos for miss tiles
   LDA #$06
-  AND $1E        ; isolate bits 1-2 to get tile index (0, 2, or 4)
+  AND $1E         ; isolate bits 1-2 to get tile index (0, 2, or 4)
   TAX
-  REP #$20       ; 16-bit A
-  LDA MissOff,X  ; load tile data offset for miss message
+  REP #$20        ; 16-bit A
+  LDA.L MissOff,X ; load tile data offset for miss message
   JMP Prep2
 
 padbyte $FF
-pad $C1A531      ; 1 unused byte
+pad $C1A531       ; 1 unused byte
 
 ; ----------------------------------------------------------------------
 ; Label for informative miss

--- a/asm/banks/c1.asm
+++ b/asm/banks/c1.asm
@@ -56,7 +56,7 @@ UpdateAura:
 SetColor:
   AND #$E0           ; clear "wait" bit
   JSR $1A0F          ; convert bitmask to bit index in X
-  LDA.L .clr_table,X ; get outline colour
+  LDA.l .clr_table,X ; get outline colour
 .clr_table
   BRA AuraControl  ; implement
   db $04 ; Slow [unused]
@@ -734,7 +734,7 @@ PrepMove:
   AND $1E         ; isolate bits 1-2 to get tile index (0, 2, or 4)
   TAX
   REP #$20        ; 16-bit A
-  LDA.L MissOff,X ; load tile data offset for miss message
+  LDA.l MissOff,X ; load tile data offset for miss message
   JMP Prep2
 
 padbyte $FF

--- a/asm/banks/c2.asm
+++ b/asm/banks/c2.asm
@@ -694,7 +694,7 @@ TargetDamageMod:
   LDA $B2          ; attack bytes (looking at $B3)
   BPL .exit        ; exit if "Ignore Vanish" (sap/regen/poison)
 
-.self-dmg
+.self_dmg
   LDA $11A4        ; attack flags
   LSR              ; carry: "Healing"
   LDA $F0          ; damage so far

--- a/asm/banks/c2.asm
+++ b/asm/banks/c2.asm
@@ -213,12 +213,12 @@ UncontrollableCmds:
   LDX $F4            ; N: "Uncontrollable but not Berserked"
   BMI .no_bserk      ; branch if ^
   JSR $5217          ; X: index to bitmask, A: command bit in bitmask
-  AND.L ZombieCmds,X  ; command allowed when Berserked/Zombied
+  AND.l ZombieCmds,X  ; command allowed when Berserked/Zombied
   BEQ .skip2         ; branch if not ^
   BRA .skip3         ; else, branch
 .no_bserk
   JSR $5217          ; X: index to bitmask, A: command bit in bitmask
-  AND.L MuddleCmds,X  ; command allowed when Muddled/Charmed/Colosseum
+  AND.l MuddleCmds,X  ; command allowed when Muddled/Charmed/Colosseum
   BNE .skip3         ; branch if ^
 .skip2
   LDA #$FF           ; "null" command
@@ -229,7 +229,7 @@ UncontrollableCmds:
   LDA $01,S          ; current command
   LDX #$0B           ; prep next loop
 .special_loop
-  CMP.L SpecialCmds,X ; matches command requiring special function
+  CMP.l SpecialCmds,X ; matches command requiring special function
   BNE .next          ; branch to next if not ^
   TXA                ; table index
   ASL                ; x2
@@ -1737,9 +1737,9 @@ org $C226A0 : AND #$FE78 ; allow "Stop" immunity (EE -> FE)
 org $C22708
 ToolSkeanSpells:
   LDX #$06                 ; iterator for list of Spells as Tools/Skeans
-  CMP.L Tool_Data_1,X      ; check if this tool matches ^
+  CMP.l Tool_Data_1,X      ; check if this tool matches ^
   BNE .skip                ; exit if not ^
-  SBC.L Tool_Data_2,X      ; else, get spell number TODO: Just LDA
+  SBC.l Tool_Data_2,X      ; else, get spell number TODO: Just LDA
 org $C22716 : .skip
 
 ; -------------------------------------------------------------------------
@@ -3995,7 +3995,7 @@ DisableCommands:
   PHP                ; store flags
   REP #$30           ; 16-bit A,X/Y
   TXY                ; Y: character index
-  LDA.L MenuOffsets,X ; character menu data offset
+  LDA.l MenuOffsets,X ; character menu data offset
   TAX                ; index it
   SEP #$20           ; 8-bit A
   LDA $3018,Y        ; character unique bit
@@ -4028,7 +4028,7 @@ DisableCommands:
   LSR                ; restore command ID (was ROR, causing CPX above to bug out)
   LDX #$0009         ; initialize command loop
 .loop
-  CMP.L ModifyCmds,X ; current command matches special case
+  CMP.l ModifyCmds,X ; current command matches special case
   BNE .next          ; branch if not ^
   TXA                ; matched command index
   ASL                ; matched command index *2
@@ -4126,7 +4126,7 @@ CommandConversions:
   PHP               ; store flags
   REP #$30          ; 16-bit A, X/Y
   LDY $3010,X       ; offset to character info data
-  LDA.L MenuOffsets,X ; offset to character menu data
+  LDA.l MenuOffsets,X ; offset to character menu data
   STA $002181       ; set WRAM destination address
   LDA $1616,Y       ; commands 1 and 2
   STA $FC           ; save ^
@@ -4193,7 +4193,7 @@ CommandConversions:
 
   LDX #$05          ; prep special command loop
 .cmd_loop
-  CMP.L CmdBlanks,X ; matches blankable command
+  CMP.l CmdBlanks,X ; matches blankable command
   BNE .next         ; branch if not ^
   TXA               ; index to blankable command
   ASL               ; x2 for jump table
@@ -4741,7 +4741,7 @@ ELTable:
   db $00,$00 ; null - Raiden?
 
 AddEL:
-  LDA.L ELTable,X ; A = full 2-byte boost
+  LDA.l ELTable,X ; A = full 2-byte boost
   SEP #$20        ; 8-bit A
 .doone
   TYX             ; X = index to character stats

--- a/asm/banks/c2.asm
+++ b/asm/banks/c2.asm
@@ -213,12 +213,12 @@ UncontrollableCmds:
   LDX $F4            ; N: "Uncontrollable but not Berserked"
   BMI .no_bserk      ; branch if ^
   JSR $5217          ; X: index to bitmask, A: command bit in bitmask
-  AND ZombieCmds,X   ; command allowed when Berserked/Zombied
+  AND.L ZombieCmds,X  ; command allowed when Berserked/Zombied
   BEQ .skip2         ; branch if not ^
   BRA .skip3         ; else, branch
 .no_bserk
   JSR $5217          ; X: index to bitmask, A: command bit in bitmask
-  AND MuddleCmds,X   ; command allowed when Muddled/Charmed/Colosseum
+  AND.L MuddleCmds,X  ; command allowed when Muddled/Charmed/Colosseum
   BNE .skip3         ; branch if ^
 .skip2
   LDA #$FF           ; "null" command
@@ -229,7 +229,7 @@ UncontrollableCmds:
   LDA $01,S          ; current command
   LDX #$0B           ; prep next loop
 .special_loop
-  CMP SpecialCmds,X  ; matches command requiring special function
+  CMP.L SpecialCmds,X ; matches command requiring special function
   BNE .next          ; branch to next if not ^
   TXA                ; table index
   ASL                ; x2
@@ -1737,9 +1737,9 @@ org $C226A0 : AND #$FE78 ; allow "Stop" immunity (EE -> FE)
 org $C22708
 ToolSkeanSpells:
   LDX #$06                 ; iterator for list of Spells as Tools/Skeans
-  CMP Tool_Data_1,X        ; check if this tool matches ^
+  CMP.L Tool_Data_1,X      ; check if this tool matches ^
   BNE .skip                ; exit if not ^
-  SBC Tool_Data_2,X        ; else, get spell number TODO: Just LDA
+  SBC.L Tool_Data_2,X      ; else, get spell number TODO: Just LDA
 org $C22716 : .skip
 
 ; -------------------------------------------------------------------------
@@ -3995,7 +3995,7 @@ DisableCommands:
   PHP                ; store flags
   REP #$30           ; 16-bit A,X/Y
   TXY                ; Y: character index
-  LDA MenuOffsets,X  ; character menu data offset
+  LDA.L MenuOffsets,X ; character menu data offset
   TAX                ; index it
   SEP #$20           ; 8-bit A
   LDA $3018,Y        ; character unique bit
@@ -4028,7 +4028,7 @@ DisableCommands:
   LSR                ; restore command ID (was ROR, causing CPX above to bug out)
   LDX #$0009         ; initialize command loop
 .loop
-  CMP ModifyCmds,X   ; current command matches special case
+  CMP.L ModifyCmds,X ; current command matches special case
   BNE .next          ; branch if not ^
   TXA                ; matched command index
   ASL                ; matched command index *2
@@ -4126,7 +4126,7 @@ CommandConversions:
   PHP               ; store flags
   REP #$30          ; 16-bit A, X/Y
   LDY $3010,X       ; offset to character info data
-  LDA MenuOffsets,X ; offset to character menu data
+  LDA.L MenuOffsets,X ; offset to character menu data
   STA $002181       ; set WRAM destination address
   LDA $1616,Y       ; commands 1 and 2
   STA $FC           ; save ^
@@ -4193,7 +4193,7 @@ CommandConversions:
 
   LDX #$05          ; prep special command loop
 .cmd_loop
-  CMP CmdBlanks,X   ; matches blankable command
+  CMP.L CmdBlanks,X ; matches blankable command
   BNE .next         ; branch if not ^
   TXA               ; index to blankable command
   ASL               ; x2 for jump table
@@ -4741,7 +4741,7 @@ ELTable:
   db $00,$00 ; null - Raiden?
 
 AddEL:
-  LDA ELTable,X   ; A = full 2-byte boost
+  LDA.L ELTable,X ; A = full 2-byte boost
   SEP #$20        ; 8-bit A
 .doone
   TYX             ; X = index to character stats

--- a/asm/banks/c3.asm
+++ b/asm/banks/c3.asm
@@ -2382,7 +2382,7 @@ ChkEsp:
   LDA $E0           ; load esper ID
   AND #$07          ; which bit of the equippability byte corresponds to this esper?
   TAY
-  LDA EsperData,X   ; get equippability byte for esper/character pair
+  LDA.L EsperData,X ; get equippability byte for esper/character pair
 - LSR               ; Do: shift right
   DEY               ; | Y--
   BPL -             ; + loop until Y negative
@@ -2868,7 +2868,7 @@ Unspent_EL:
   JSR $3519         ; initialize WRAM buffer with ^
   LDX $00           ; zero X
 .write_uel
-  LDA UnspentTxt,X  ; get "Unspent EL:" tile
+  LDA.L UnspentTxt,X ; get "Unspent EL:" tile
   BEQ .finish       ; break if EOL
   STA $2180         ; else, write to WRAM
   INX               ; next tile index

--- a/asm/banks/c3.asm
+++ b/asm/banks/c3.asm
@@ -3307,7 +3307,7 @@ Learn_Chk:
 Pressed_A:
   LDA $4B           ; pointer index
   BNE .spell        ; branch if pointing at a spell
-  JMP $C358DF       ; vanilla "can equip esper" fork
+  JML $C358DF       ; vanilla "can equip esper" fork TODO: Use JMP
 .spell
   LDA $99           ; load esper ID
   STA $4202         ; set multiplier

--- a/asm/banks/c3.asm
+++ b/asm/banks/c3.asm
@@ -2382,7 +2382,7 @@ ChkEsp:
   LDA $E0           ; load esper ID
   AND #$07          ; which bit of the equippability byte corresponds to this esper?
   TAY
-  LDA.L EsperData,X ; get equippability byte for esper/character pair
+  LDA.l EsperData,X ; get equippability byte for esper/character pair
 - LSR               ; Do: shift right
   DEY               ; | Y--
   BPL -             ; + loop until Y negative
@@ -2868,7 +2868,7 @@ Unspent_EL:
   JSR $3519         ; initialize WRAM buffer with ^
   LDX $00           ; zero X
 .write_uel
-  LDA.L UnspentTxt,X ; get "Unspent EL:" tile
+  LDA.l UnspentTxt,X ; get "Unspent EL:" tile
   BEQ .finish       ; break if EOL
   STA $2180         ; else, write to WRAM
   INX               ; next tile index

--- a/asm/banks/c3.asm
+++ b/asm/banks/c3.asm
@@ -287,7 +287,7 @@ org $C33BB7
   RTS           ; automatically return from battle speed jump
 BNWText:   dw $78D1 : db "  Brave New World 2.1.0",$00
                       db "8 ",$00 ; TODO: Remove this text fragment
-BattleTxt: dw $3A4F : db "Battle","$00
+BattleTxt: dw $3A4F : db "Battle",$00
 warnpc $C33BDE+1
 padbyte $FF
 pad $C33BDE

--- a/scripts/assemble.sh
+++ b/scripts/assemble.sh
@@ -7,7 +7,7 @@ source "./settings.sh"
 
 # Helpers
 assemble () {
-  "${XKAS_PATH[@]}" $1 ../$rom_path
+  "$ASAR_PATH" $1 ../$rom_path
 }
 assemble_batch () {
   cd ../asm/$1

--- a/scripts/settings.local.sh
+++ b/scripts/settings.local.sh
@@ -4,6 +4,6 @@
 # Then fill out the following environment variables with the correct
 # paths to the utilities listed.
 
-XKAS_PATH=("path/to/xkas") # Array format to support wine
+ASAR_PATH="path/to/asar" # See "https://github.com/RPGHacker/asar"
 IPS_PATH="path/to/ips_utility" # Using `flips` for now
 BASE_FF6="path/to/unheadered/ff6" # Must be unheadered v1.1


### PR DESCRIPTION
Switch from `xkas` to `asar` for assembly. Our existing `asm` works with only very slight modification to ambiguous `LDA.L` usage.

Primary benefits of switch to ASAR:
1. Performance
2. Features
3. Actively maintained
4. Better support for Linux/maxOS
5. Validation of malformed asm