### PR TITLE
Halfturn blitz

### DIFF
--- a/asm/banks/c2.asm
+++ b/asm/banks/c2.asm
@@ -1080,6 +1080,12 @@ org $C21592
   JSR CoinHelp ; Redirect Steal to helper used by GP Rain
 
 ; #########################################################################
+; Blitz Command
+; Modified to consume only 50% ATB on failure
+
+org $C215A7 : JSR BlitzSlice
+
+; #########################################################################
 ; Fight (command)
 
 org $C215D1 : NOP #2   ; Enable desperation attacks at any time (nATB)
@@ -3870,11 +3876,22 @@ PetrifyHelp:
   RTS
 
 ; -------------------------------------------------------------------------
-; Helper for Half Turn ATB
+; Helper for Blitz Halfturn
+
+BlitzSlice:
+  STA $3401      ; [displaced] set msg "Incorrect Blitz input!"
+  BRA HalfTurnY  ; set ATB to 50%
+
+; -------------------------------------------------------------------------
+; Helpers for Half Turn ATB (two versions based on index X vs. Y)
 
 HalfTurn:
   LDA #$7E       ; half-full ATB
   STA $3219,X    ; set new ATB value
+  RTS
+HalfTurnY:
+  LDA #$7E       ; half-full ATB
+  STA $3219,Y    ; set new ATB value
   RTS
 
 ; -------------------------------------------------------------------------

--- a/asm/reference/halfturn_blitz.asm
+++ b/asm/reference/halfturn_blitz.asm
@@ -1,0 +1,36 @@
+arch 65816
+hirom
+
+!free = $EFFBDA ; point this at a big chunk
+
+; patches utilizing consecutive freespace:
+
+!HalfTurnBlitz_freespace = !free
+
+; next = HalfTurnBlitzFailure_EOF
+
+warnpc $EFFC00
+
+org $C215A5
+  JSL BlitzSlice
+  NOP
+
+org !HalfTurnBlitz_freespace
+BlitzSlice:
+  LDA #$43
+  STA $3401         ; Set to display text "Incorrect Blitz input!"
+  JSR HalfATBY      ; set ATB to 50%
+  RTL
+
+; A wrapper for $C1/8A0E for when you have character index
+; loaded in Y instead of X. This is used in a few other
+; patches as well.
+
+HalfATBY:
+  PHX
+  TYX
+  JSL $C18A0E         ; set ATB to 50%
+  PLX
+  RTS
+
+HalfATBBlitz_EOF:


### PR DESCRIPTION
On input failure, Blitz only consumes 50% ATB